### PR TITLE
Reconfiguring setup leaves connection inconsistent

### DIFF
--- a/lib/active_directory/base.rb
+++ b/lib/active_directory/base.rb
@@ -46,6 +46,7 @@ module ActiveDirectory
 		#     :port => 389,
 		#     :base => 'dc=example,dc=org',
 		#     :auth => {
+		#	:method	=> :simple,
 		#       :username => 'querying_user@example.org',
 		#       :password => 'querying_users_password'
 		#     }
@@ -65,6 +66,7 @@ module ActiveDirectory
 		#
 		def self.setup(settings)
 			@@settings = settings
+			@@ldap_connected = false
 			@@ldap = Net::LDAP.new(settings)
 		end
 


### PR DESCRIPTION
Right now if you call setup the current behaviour is to
overwrite the existing connection anyway, and without reseting the
ldap_connected variable it would leave the object in an inconsistent
state.  That variable should be reset when a reconnect is issued.
