### PR TITLE
Special fields for computers

### DIFF
--- a/lib/active_directory.rb
+++ b/lib/active_directory.rb
@@ -81,5 +81,15 @@ module ActiveDirectory
       :memberof => :GroupDnArray,
       :member => :MemberDnArray,
     },
+
+    #Computer objects
+    :Computer => {
+      :objectguid => :Binary,
+      :whencreated => :Date,
+      :whenchanged => :Date,
+      :objectsid => :Binary,
+      :memberof => :GroupDnArray,
+      :member => :MemberDnArray,
+    },
   }
 end


### PR DESCRIPTION
Fixing a bug where calling an get_attr method on a computer(:all) array will return an undefined method `[]=' for nil:NilClass error.
