### PR TITLE
Fix for User.groups undefined method memberOf.

### DIFF
--- a/lib/active_directory/user.rb
+++ b/lib/active_directory/user.rb
@@ -76,7 +76,7 @@ module ActiveDirectory
 		# called Marketting, this method would only return the Sales group.
 		#
 		def groups
-			@groups ||= Group.find(:all, :distinguishedname => @entry.memberOf)
+			@groups ||= Group.find(:all, :distinguishedname => @entry[:memberOf] )
 		end
 
 		#


### PR DESCRIPTION
The groups method of the User class would call @entry.memberOf. Normally this works fine, but sometimes the memberOf method is undefined (when the user in question is not a member of any groups). I changed it to instead use the [] method to read the memberOf attribute.