### PR TITLE
Fixed Group.member_users and member_groups to work with empty groups

### DIFF
--- a/lib/active_directory/group.rb
+++ b/lib/active_directory/group.rb
@@ -98,8 +98,7 @@ module ActiveDirectory
 		# belong to this Group, or any of its subgroups, are returned.
 		# 
 		def member_users(recursive = false)
-			return [] unless @entry.respond_to?(:member)
-                        @member_users = User.find(:all, :distinguishedname => @entry.member).delete_if { |u| u.nil? }
+                        @member_users = User.find(:all, :distinguishedname => @entry[:member]).delete_if { |u| u.nil? }
                         if recursive then
                           self.member_groups.each do |group|
                             @member_users.concat(group.member_users(true))
@@ -118,7 +117,7 @@ module ActiveDirectory
 		# belong to this Group, or any of its subgroups, are returned.
 		# 
 		def member_groups(recursive = false)
-                        @member_groups ||= Group.find(:all, :distinguishedname => @entry.member).delete_if { |g| g.nil? }
+                        @member_groups ||= Group.find(:all, :distinguishedname => @entry[:member]).delete_if { |g| g.nil? }
                         if recursive then
                           self.member_groups.each do |group|
                             @member_groups.concat(group.member_groups(true))


### PR DESCRIPTION
The Group.member_users and Group.member_groups methods would fail when
empty groups are present in the hierarchy.  Changed the access method
to [:member] to return an empty array instead.
