### PR TITLE
Fix bug in set_attr

### DIFF
--- a/lib/active_directory/base.rb
+++ b/lib/active_directory/base.rb
@@ -555,7 +555,7 @@ module ActiveDirectory
 		end
 
 		def set_attr(name, value)
-			@attributes[name.to_sym] = encode_field(name, value)
+			@attributes[name.to_sym] = self.class.encode_field(name, value)
 		end
 
 		##

--- a/lib/active_directory/base.rb
+++ b/lib/active_directory/base.rb
@@ -422,7 +422,8 @@ module ActiveDirectory
 			begin
 				attributes.merge!(required_attributes)
 				if @@ldap.add(:dn => dn.to_s, :attributes => attributes)
-					return find_by_distinguishedName(dn.to_s)
+					ldap_obj= @@ldap.search(:base => dn.to_s)
+					return new(ldap_obj[0])
 				else
 					return nil
 				end


### PR DESCRIPTION
`encode_field` is a class method being called in an instance method.

There seem to be other places in the code where this is incorrect, but this is the only one we needed to change to get our situation to work.