### PR TITLE
Avoid explicit conversion error by ensuring we're comparing the DN as a ...

### DIFF
--- a/lib/active_directory/member.rb
+++ b/lib/active_directory/member.rb
@@ -28,7 +28,7 @@ module ActiveDirectory
 			group_dns = memberOf
 			return false if group_dns.nil? || group_dns.empty?
 			#group_dns = [group_dns] unless group_dns.is_a?(Array)
-			group_dns.include?(usergroup.dn)
+			group_dns.map{ |g| g.dn }.include?(usergroup.dn)
 		end
 
 		#


### PR DESCRIPTION
(Full commit title:) "Avoid explicit conversion error by ensuring we're comparing the DN as a string against the other DNs as a string."

I was receiving the error:

    TypeError: no implicit conversion of Symbol into Integer
	from /usr/local/lib/ruby/gems/2.1.0/bundler/gems/active_directory-2bf3e8dba161/lib/active_directory/base.rb:345:in `[]'
	from /usr/local/lib/ruby/gems/2.1.0/bundler/gems/active_directory-2bf3e8dba161/lib/active_directory/base.rb:345:in `=='
	from /usr/local/lib/ruby/gems/2.1.0/bundler/gems/active_directory-2bf3e8dba161/lib/active_directory/member.rb:32:in `include?'
	from /usr/local/lib/ruby/gems/2.1.0/bundler/gems/active_directory-2bf3e8dba161/lib/active_directory/member.rb:32:in `member_of?'

It turns out member.rb's member_of? function does this:

    group_dns.include?(usergroup.dn)

which against my organization's AD server results in group_dns being an array of objects and usergroup.dn being a string. That compare operator then takes the string as an argument and asks for [:objectguid], throwing the error.

(In short, we end up asking Ruby to do something like "cn=something"[:objectguid], which throws the error.)

Simply removing the ".dn" and letting Ruby compare objects with objects seems to fix the error here.

I'm not sure why the ".dn" would have worked in the first place, which is troublesome.